### PR TITLE
[FEATURE] 6주차 미션_셔나 

### DIFF
--- a/셔나/server/src/main/java/umc/server/domain/member/service/MemberService.java
+++ b/셔나/server/src/main/java/umc/server/domain/member/service/MemberService.java
@@ -14,7 +14,6 @@ import umc.server.domain.member.exception.code.FoodErrorCode;
 import umc.server.domain.member.exception.code.MemberErrorCode;
 import umc.server.domain.member.repository.FoodRepository;
 import umc.server.domain.member.repository.MemberRepository;
-import umc.server.global.apiPayload.exception.GeneralException;
 
 import java.util.List;
 

--- a/셔나/server/src/main/java/umc/server/domain/mission/controller/MissionController.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/controller/MissionController.java
@@ -15,8 +15,8 @@ public class MissionController {
 
     private final MissionService missionService;
 
-    @GetMapping
-    public ApiResponse<MissionResDTO.GetMissionListDTO> getMissionList(
+    @GetMapping("/me")
+    public ApiResponse<MissionResDTO.GetMissionListDTO> findMissionList(
             @RequestParam(name = "memberId") Long memberId,
             @RequestParam(name = "status") MissionStatus status
     ) {
@@ -29,5 +29,12 @@ public class MissionController {
             @RequestParam(name = "memberId") Long memberId
     ) {
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_STATUS_UPDATED, missionService.updateMissionCompleted(memberId, missionId));
+    }
+
+    @GetMapping("/home/{storeRegion}")
+    public ApiResponse<MissionResDTO.GetHomeMissionListDTO> findHomeMissionList(
+            @PathVariable String storeRegion
+    ) {
+        return ApiResponse.onSuccess(MissionSuccessCode.MISSION_FOUND, missionService.getHomeMissionList(storeRegion));
     }
 }

--- a/셔나/server/src/main/java/umc/server/domain/mission/controller/MissionController.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/controller/MissionController.java
@@ -31,9 +31,9 @@ public class MissionController {
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_STATUS_UPDATED, missionService.updateMissionCompleted(memberId, missionId));
     }
 
-    @GetMapping("/home/{storeRegion}")
+    @GetMapping("/home")
     public ApiResponse<MissionResDTO.GetHomeMissionListDTO> findHomeMissionList(
-            @PathVariable String storeRegion
+            @RequestParam(name = "region") String storeRegion
     ) {
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_FOUND, missionService.getHomeMissionList(storeRegion));
     }

--- a/셔나/server/src/main/java/umc/server/domain/mission/converter/MissionConverter.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/converter/MissionConverter.java
@@ -2,6 +2,7 @@ package umc.server.domain.mission.converter;
 
 import umc.server.domain.mission.dto.MissionResDTO;
 import umc.server.domain.mission.entity.MemberMission;
+import umc.server.domain.mission.entity.Mission;
 
 import java.util.List;
 
@@ -35,6 +36,29 @@ public class MissionConverter {
         return MissionResDTO.UpdateMissionStatusResultDTO.builder()
                 .missionId(memberMission.getMission().getId())
                 .missionStatus(memberMission.getMissionStatus())
+                .build();
+    }
+
+    // entity -> 홈 미션 조회 DTO
+    public static MissionResDTO.HomeMissionDTO toHomeMissionDTO(Mission mission) {
+        return MissionResDTO.HomeMissionDTO.builder()
+                .missionId(mission.getId())
+                .storeName(mission.getStore().getStoreName())
+                .category(mission.getStore().getCategory())
+                .missionTitle(mission.getMissionTitle())
+                .rewardPoints(mission.getRewardPoints())
+                .deadline(mission.getDeadline())
+                .build();
+    }
+
+    // entity -> 홈 미션 목록 조회 DTO
+    public static MissionResDTO.GetHomeMissionListDTO toGetHomeMissionListDTO(List<Mission> missionList) {
+        List<MissionResDTO.HomeMissionDTO> homeMissionDTOList = missionList.stream()
+                .map(MissionConverter::toHomeMissionDTO)
+                .toList();
+
+        return MissionResDTO.GetHomeMissionListDTO.builder()
+                .homeMissionList(homeMissionDTOList)
                 .build();
     }
 }

--- a/셔나/server/src/main/java/umc/server/domain/mission/dto/MissionResDTO.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/dto/MissionResDTO.java
@@ -3,6 +3,7 @@ package umc.server.domain.mission.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import umc.server.domain.mission.enums.MissionStatus;
+import umc.server.domain.store.enums.StoreCategory;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,5 +29,20 @@ public class MissionResDTO {
     public record UpdateMissionStatusResultDTO(
             Long missionId,
             MissionStatus missionStatus
+    ) {}
+
+    @Builder
+    public record HomeMissionDTO(
+            Long missionId,
+            String storeName,
+            StoreCategory category,
+            String missionTitle,
+            Integer rewardPoints,
+            LocalDateTime deadline
+    ) {}
+
+    @Builder
+    public record GetHomeMissionListDTO(
+            List<HomeMissionDTO> homeMissionList
     ) {}
 }

--- a/셔나/server/src/main/java/umc/server/domain/mission/entity/Mission.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/entity/Mission.java
@@ -52,4 +52,18 @@ public class Mission extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
+
+    // 연관관계 편의 메서드
+    public void setStore(Store store) {
+        // 기존에 연결된 가게가 있다면 제거
+        if (this.store != null) {
+            this.store.getMissionList().remove(this);
+        }
+        this.store = store;
+
+        // 가게 쪽에서도 이 미션을 목록에 추가 (양방향 동기화)
+        if (store != null) {
+            store.getMissionList().add(this);
+        }
+    }
 }

--- a/셔나/server/src/main/java/umc/server/domain/mission/entity/Mission.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/entity/Mission.java
@@ -54,7 +54,7 @@ public class Mission extends BaseEntity {
     private Store store;
 
     // 연관관계 편의 메서드
-    public void setStore(Store store) {
+    public void assignToStore(Store store) {
         // 기존에 연결된 가게가 있다면 제거
         if (this.store != null) {
             this.store.getMissionList().remove(this);

--- a/셔나/server/src/main/java/umc/server/domain/mission/repository/MemberMissionRepository.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/repository/MemberMissionRepository.java
@@ -1,6 +1,7 @@
 package umc.server.domain.mission.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import umc.server.domain.mission.entity.MemberMission;
 import umc.server.domain.mission.enums.MissionStatus;
@@ -12,8 +13,10 @@ import java.util.Optional;
 public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
 
     // 특정 회원의 상태별 미션 목록 조회 (진행중/진행완료)
+    @Query("SELECT mm FROM MemberMission mm JOIN FETCH mm.mission WHERE mm.member.id = :memberId AND mm.missionStatus = :status")
     List<MemberMission> findAllByMemberIdAndMissionStatus(Long memberId, MissionStatus status);
 
     // 특정 회원의 특정 미션 기록 찾기
+    @Query("SELECT mm FROM MemberMission mm WHERE mm.member.id = :memberId AND mm.mission.id = :missionId")
     Optional<MemberMission> findByMemberIdAndMissionId(Long memberId, Long missionId);
 }

--- a/셔나/server/src/main/java/umc/server/domain/mission/repository/MissionRepository.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/repository/MissionRepository.java
@@ -1,10 +1,15 @@
 package umc.server.domain.mission.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import umc.server.domain.mission.entity.Mission;
+
+import java.util.List;
 
 @Repository
 public interface MissionRepository extends JpaRepository<Mission, Long> {
 
+    @Query("SELECT m FROM Mission m JOIN FETCH m.store s WHERE s.storeRegion = :regionName")
+    List<Mission> findAllByRegionName(String regionName);
 }

--- a/셔나/server/src/main/java/umc/server/domain/mission/service/MissionService.java
+++ b/셔나/server/src/main/java/umc/server/domain/mission/service/MissionService.java
@@ -6,11 +6,12 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.server.domain.mission.converter.MissionConverter;
 import umc.server.domain.mission.dto.MissionResDTO;
 import umc.server.domain.mission.entity.MemberMission;
+import umc.server.domain.mission.entity.Mission;
 import umc.server.domain.mission.enums.MissionStatus;
 import umc.server.domain.mission.exception.MissionException;
 import umc.server.domain.mission.exception.code.MissionErrorCode;
 import umc.server.domain.mission.repository.MemberMissionRepository;
-import umc.server.global.apiPayload.exception.GeneralException;
+import umc.server.domain.mission.repository.MissionRepository;
 
 import java.util.List;
 
@@ -20,6 +21,7 @@ import java.util.List;
 public class MissionService {
 
     private final MemberMissionRepository memberMissionRepository;
+    private final MissionRepository missionRepository;
 
     public MissionResDTO.GetMissionListDTO getMissionList(Long memberId, MissionStatus missionStatus) {
         List<MemberMission> memberMissionList = memberMissionRepository.findAllByMemberIdAndMissionStatus(memberId, missionStatus);
@@ -35,5 +37,11 @@ public class MissionService {
         memberMission.missionComplete();
 
         return MissionConverter.toUpdateMissionStatusResultDTO(memberMission);
+    }
+
+    public MissionResDTO.GetHomeMissionListDTO getHomeMissionList(String regionName) {
+        List<Mission> missionList = missionRepository.findAllByRegionName(regionName);
+
+        return MissionConverter.toGetHomeMissionListDTO(missionList);
     }
 }

--- a/셔나/server/src/main/java/umc/server/domain/review/controller/ReviewController.java
+++ b/셔나/server/src/main/java/umc/server/domain/review/controller/ReviewController.java
@@ -2,10 +2,7 @@ package umc.server.domain.review.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.server.domain.review.dto.ReviewReqDTO;
 import umc.server.domain.review.dto.ReviewResDTO;
 import umc.server.domain.review.exception.code.ReviewSuccessCode;
@@ -24,5 +21,12 @@ public class ReviewController {
             @RequestBody @Valid ReviewReqDTO.CreateReviewDTO request
     ) {
         return ApiResponse.onSuccess(ReviewSuccessCode.CREATED, reviewService.createReview(request));
+    }
+
+    @GetMapping("/{storeId}")
+    public ApiResponse<ReviewResDTO.GetReviewListDTO> findReviewList(
+            @PathVariable Long storeId
+    ) {
+        return ApiResponse.onSuccess(ReviewSuccessCode.OK, reviewService.getReviewList(storeId));
     }
 }

--- a/셔나/server/src/main/java/umc/server/domain/review/converter/ReviewConverter.java
+++ b/셔나/server/src/main/java/umc/server/domain/review/converter/ReviewConverter.java
@@ -2,10 +2,12 @@ package umc.server.domain.review.converter;
 
 import umc.server.domain.review.dto.ReviewReqDTO;
 import umc.server.domain.review.dto.ReviewResDTO;
+import umc.server.domain.review.entity.Reply;
 import umc.server.domain.review.entity.Review;
 import umc.server.domain.review.entity.ReviewPhoto;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class ReviewConverter {
 
@@ -30,8 +32,40 @@ public class ReviewConverter {
     // entity -> 리뷰 작성 DTO
     public static ReviewResDTO.CreateReviewResultDTO toCreateReviewResultDTO(Review review) {
         return ReviewResDTO.CreateReviewResultDTO.builder()
+                .reviewId(review.getId())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+
+    // entity -> 리뷰 조회 DTO
+    public static ReviewResDTO.ReviewDTO toReviewDTO(Review review) {
+        List<String> reviewPhotoList = review.getReviewPhotoList().stream()
+                .map(ReviewPhoto::getPhotoUrl)
+                .toList();
+
+        List<String> replyContents = review.getReplyList().stream()
+                .map(Reply::getContent)
+                .toList();
+
+        return ReviewResDTO.ReviewDTO.builder()
+                .reviewId(review.getId())
+                .nickname(review.getMember().getNickname())
                 .rating(review.getRating())
                 .comment(review.getComment())
+                .photoUrls(reviewPhotoList)
+                .createdAt(review.getCreatedAt())
+                .reviewReplies(replyContents)
+                .build();
+    }
+
+    // entity -> 리뷰 목록 조회 DTO
+    public static ReviewResDTO.GetReviewListDTO toGetReviewResultDTO(List<Review> reviewList) {
+        List<ReviewResDTO.ReviewDTO> reviewDTOList = reviewList.stream()
+                .map(ReviewConverter::toReviewDTO)
+                .toList();
+
+        return ReviewResDTO.GetReviewListDTO.builder()
+                .reviewList(reviewDTOList)
                 .build();
     }
 }

--- a/셔나/server/src/main/java/umc/server/domain/review/dto/ReviewResDTO.java
+++ b/셔나/server/src/main/java/umc/server/domain/review/dto/ReviewResDTO.java
@@ -3,12 +3,30 @@ package umc.server.domain.review.dto;
 import lombok.Builder;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class ReviewResDTO {
 
     @Builder
     public record CreateReviewResultDTO(
+            Long reviewId,
+            LocalDateTime createdAt
+    ) {}
+
+    @Builder
+    public record ReviewDTO(
+            Long reviewId,
+            String nickname,
             BigDecimal rating,
-            String comment
+            String comment,
+            List<String> photoUrls,
+            LocalDateTime createdAt,
+            List<String> reviewReplies  // 사장님이 단 답글이 있다면 함께 반환
+    ) {}
+
+    @Builder
+    public record GetReviewListDTO(
+            List<ReviewDTO> reviewList
     ) {}
 }

--- a/셔나/server/src/main/java/umc/server/domain/review/exception/code/ReviewSuccessCode.java
+++ b/셔나/server/src/main/java/umc/server/domain/review/exception/code/ReviewSuccessCode.java
@@ -9,7 +9,8 @@ import umc.server.global.apiPayload.code.BaseSuccessCode;
 @RequiredArgsConstructor
 public enum ReviewSuccessCode implements BaseSuccessCode {
 
-    CREATED(HttpStatus.CREATED, "REVIEW201", "리뷰가 성공적으로 작성되었습니다.")
+    OK(HttpStatus.OK, "REVIEW200_1", "성공적으로 리뷰를 조회했습니다."),
+    CREATED(HttpStatus.CREATED, "REVIEW201_1", "리뷰가 성공적으로 작성되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/셔나/server/src/main/java/umc/server/domain/review/repository/ReviewRepository.java
+++ b/셔나/server/src/main/java/umc/server/domain/review/repository/ReviewRepository.java
@@ -1,8 +1,13 @@
 package umc.server.domain.review.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import umc.server.domain.review.entity.Review;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    @Query("SELECT r FROM Review r JOIN FETCH r.member LEFT JOIN FETCH r.replyList WHERE r.store.id = :storeId")
+    List<Review> findAllByStoreIdWithReply(Long storeId);
 }

--- a/셔나/server/src/main/java/umc/server/domain/review/repository/ReviewRepository.java
+++ b/셔나/server/src/main/java/umc/server/domain/review/repository/ReviewRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.member LEFT JOIN FETCH r.replyList WHERE r.store.id = :storeId")
+    @Query("SELECT r FROM Review r JOIN FETCH r.member LEFT JOIN FETCH r.replyList LEFT JOIN FETCH r.reviewPhotoList WHERE r.store.id = :storeId")
     List<Review> findAllByStoreIdWithReply(Long storeId);
 }

--- a/셔나/server/src/main/java/umc/server/domain/review/service/ReviewService.java
+++ b/셔나/server/src/main/java/umc/server/domain/review/service/ReviewService.java
@@ -15,7 +15,8 @@ import umc.server.domain.store.entity.Store;
 import umc.server.domain.store.exception.StoreException;
 import umc.server.domain.store.exception.code.StoreErrorCode;
 import umc.server.domain.store.repository.StoreRepository;
-import umc.server.global.apiPayload.exception.GeneralException;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -47,5 +48,14 @@ public class ReviewService {
 
         // 결과 반환 (Entity -> DTO 변환)
         return ReviewConverter.toCreateReviewResultDTO(savedReview);
+    }
+
+    public ReviewResDTO.GetReviewListDTO getReviewList(Long storeId) {
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        List<Review> reviews = reviewRepository.findAllByStoreIdWithReply(storeId);
+
+        return ReviewConverter.toGetReviewResultDTO(reviews);
     }
 }

--- a/셔나/server/src/main/java/umc/server/domain/store/controller/StoreController.java
+++ b/셔나/server/src/main/java/umc/server/domain/store/controller/StoreController.java
@@ -1,4 +1,26 @@
 package umc.server.domain.store.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.server.domain.mission.entity.Mission;
+import umc.server.domain.store.dto.StoreReqDTO;
+import umc.server.domain.store.dto.StoreResDTO;
+import umc.server.domain.store.exception.code.StoreSuccessCode;
+import umc.server.domain.store.service.StoreService;
+import umc.server.global.apiPayload.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stores")
 public class StoreController {
+
+    private final StoreService storeService;
+
+    @PostMapping("/{storeId}/missions")
+    public ApiResponse<StoreResDTO.CreateMissionResultDTO> registerMission(
+            @PathVariable Long storeId,
+            @RequestBody StoreReqDTO.CreateMissionDTO request
+    ) {
+        return ApiResponse.onSuccess(StoreSuccessCode.CREATED, storeService.createMission(storeId, request));
+    }
 }

--- a/셔나/server/src/main/java/umc/server/domain/store/converter/StoreConverter.java
+++ b/셔나/server/src/main/java/umc/server/domain/store/converter/StoreConverter.java
@@ -1,4 +1,28 @@
 package umc.server.domain.store.converter;
 
+import umc.server.domain.mission.entity.Mission;
+import umc.server.domain.store.dto.StoreReqDTO;
+import umc.server.domain.store.dto.StoreResDTO;
+
 public class StoreConverter {
+
+    // DTO -> entity
+    public static Mission toMission(StoreReqDTO.CreateMissionDTO request) {
+        return Mission.builder()
+                .missionTitle(request.missionTitle())
+                .missionDescription(request.missionDescription())
+                .deadline(request.deadline())
+                .rewardPoints(request.rewardPoints())
+                .isActive(request.isActive())
+                .build();
+    }
+
+    // entity -> 가게 미션 생성 DTO
+    public static StoreResDTO.CreateMissionResultDTO toCreateMissionResultDTO(Mission mission) {
+        return StoreResDTO.CreateMissionResultDTO.builder()
+                .missionId(mission.getId())
+                .createdAt(mission.getCreatedAt())
+                .build();
+
+    }
 }

--- a/셔나/server/src/main/java/umc/server/domain/store/dto/StoreReqDTO.java
+++ b/셔나/server/src/main/java/umc/server/domain/store/dto/StoreReqDTO.java
@@ -1,4 +1,25 @@
 package umc.server.domain.store.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
 public class StoreReqDTO {
+
+    public record CreateMissionDTO(
+            @Schema(description = "미션 제목", example = "매장에서 10,000원 이상 결제")
+            String missionTitle,
+
+            @Schema(description = "미션 설명", example = "음식 메뉴 무관하게 매장에서 10,000원 이상 결제 시 포인트가 적립됩니다.")
+            String missionDescription,
+
+            @Schema(description = "미션 마감일", example = "2026-05-31T23:59:59")
+            LocalDateTime deadline,
+
+            @Schema(description = "적립 포인트", example = "10")
+            Integer rewardPoints,
+
+            @Schema(description = "미션 활성여부", example = "true")
+            boolean isActive
+    ) {}
 }

--- a/셔나/server/src/main/java/umc/server/domain/store/dto/StoreResDTO.java
+++ b/셔나/server/src/main/java/umc/server/domain/store/dto/StoreResDTO.java
@@ -1,4 +1,14 @@
 package umc.server.domain.store.dto;
 
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
 public class StoreResDTO {
+
+    @Builder
+    public record CreateMissionResultDTO(
+            Long missionId,
+            LocalDateTime createdAt
+    ) {}
 }

--- a/셔나/server/src/main/java/umc/server/domain/store/entity/Store.java
+++ b/셔나/server/src/main/java/umc/server/domain/store/entity/Store.java
@@ -29,6 +29,9 @@ public class Store extends BaseEntity {
     @Column(name = "store_name", length = 100, nullable = false)
     private String storeName;
 
+    @Column(name = "store_region", length = 20, nullable = false)
+    private String storeRegion;
+
     @Column(name = "store_address", length = 255, nullable = false)
     private String storeAddress;
 

--- a/셔나/server/src/main/java/umc/server/domain/store/exception/code/StoreSuccessCode.java
+++ b/셔나/server/src/main/java/umc/server/domain/store/exception/code/StoreSuccessCode.java
@@ -1,4 +1,18 @@
 package umc.server.domain.store.exception.code;
 
-public enum StoreSuccessCode {
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import umc.server.global.apiPayload.code.BaseSuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum StoreSuccessCode implements BaseSuccessCode {
+
+    CREATED(HttpStatus.CREATED, "STORE201_1", "성공적으로 가게 미션을 생성했습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/셔나/server/src/main/java/umc/server/domain/store/service/StoreService.java
+++ b/셔나/server/src/main/java/umc/server/domain/store/service/StoreService.java
@@ -1,4 +1,36 @@
 package umc.server.domain.store.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.server.domain.mission.entity.Mission;
+import umc.server.domain.mission.repository.MissionRepository;
+import umc.server.domain.store.converter.StoreConverter;
+import umc.server.domain.store.dto.StoreReqDTO;
+import umc.server.domain.store.dto.StoreResDTO;
+import umc.server.domain.store.entity.Store;
+import umc.server.domain.store.exception.StoreException;
+import umc.server.domain.store.exception.code.StoreErrorCode;
+import umc.server.domain.store.repository.StoreRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StoreService {
+
+    private final StoreRepository storeRepository;
+    private final MissionRepository missionRepository;
+
+    @Transactional
+    public StoreResDTO.CreateMissionResultDTO createMission(Long storeId, StoreReqDTO.CreateMissionDTO request) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        Mission newMission = StoreConverter.toMission(request);
+        newMission.setStore(store);
+
+        Mission savedMission = missionRepository.save(newMission);
+
+        return StoreConverter.toCreateMissionResultDTO(savedMission);
+    }
 }

--- a/셔나/server/src/main/java/umc/server/domain/store/service/StoreService.java
+++ b/셔나/server/src/main/java/umc/server/domain/store/service/StoreService.java
@@ -27,7 +27,7 @@ public class StoreService {
                 .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
 
         Mission newMission = StoreConverter.toMission(request);
-        newMission.setStore(store);
+        newMission.assignToStore(store);
 
         Mission savedMission = missionRepository.save(newMission);
 

--- a/셔나/server/src/main/resources/application.yml
+++ b/셔나/server/src/main/resources/application.yml
@@ -17,3 +17,4 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 100


### PR DESCRIPTION
## Summary
- 가게별 리뷰 목록 조회 API, 지역별 미션 목록 조회 API, 가게별 미션 등록 API를 구현 

## Related Issue
- close #30 

## Describe your code
- 가게별 리뷰 목록 조회를 구현하여 특정 가게의 리뷰들을 한눈에 볼 수 있게 하였습니다.
  - 리뷰와 작성자 정보를 한 번의 쿼리로 효율적으로 조회(Fetch Join)하여 성능을 챙겼습니다.

- 지역별 미션 목록 조회를 구현하여 사용자가 선택한 동네(예: 안암동)의 미션들을 모아서 보여줍니다.

- 가게별 미션 등록을 구현하여 사장님이 자기 가게에 새로운 미션을 올릴 수 있습니다.

## Checklist
- [x] 리뷰어 등록
