### PR TITLE
[FEATURE] 8주차 미션_셔나

### DIFF
--- a/셔나/server/build.gradle
+++ b/셔나/server/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/셔나/server/src/main/java/umc/server/domain/member/converter/MemberConverter.java
+++ b/셔나/server/src/main/java/umc/server/domain/member/converter/MemberConverter.java
@@ -10,8 +10,10 @@ import java.util.ArrayList;
 public class MemberConverter {
 
     // DTO -> Member entity
-    public static Member toMember(MemberReqDTO.JoinDTO request) {
+    public static Member toMember(MemberReqDTO.JoinDTO request, String encodedPassword) {
         return Member.builder()
+                .email(request.email())
+                .password(encodedPassword)
                 .username(request.username())
                 .gender(request.gender())
                 .birth(request.birth())

--- a/셔나/server/src/main/java/umc/server/domain/member/dto/MemberReqDTO.java
+++ b/셔나/server/src/main/java/umc/server/domain/member/dto/MemberReqDTO.java
@@ -2,10 +2,7 @@ package umc.server.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.*;
 import umc.server.domain.member.enums.Gender;
 
 import java.time.LocalDate;
@@ -16,6 +13,16 @@ public class MemberReqDTO {
     public record JoinDTO(
             @Valid
             TermsDTO terms,
+
+            @NotBlank(message = "이메일은 필수입니다.")
+            @Email(message = "올바른 이메일 형식이어야 합니다.")
+            @Schema(description = "이메일", example = "test@example.com")
+            String email, // 추가
+
+            @NotBlank(message = "비밀번호는 필수입니다.")
+            @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+            @Schema(description = "비밀번호", example = "password123!")
+            String password,
 
             @NotBlank(message = "사용자 이름은 필수입니다.")
             @Schema(description = "사용자 이름", example = "홍길동")

--- a/셔나/server/src/main/java/umc/server/domain/member/entity/Member.java
+++ b/셔나/server/src/main/java/umc/server/domain/member/entity/Member.java
@@ -61,6 +61,9 @@ public class Member extends BaseEntity {
     @Column(name = "email", length = 100)
     private String email;
 
+    @Column(name = "password", length = 100)
+    private String password;
+
     @Column(name = "social_type")
     @Enumerated(EnumType.STRING)
     private SocialType socialType;

--- a/셔나/server/src/main/java/umc/server/domain/member/exception/code/MemberErrorCode.java
+++ b/셔나/server/src/main/java/umc/server/domain/member/exception/code/MemberErrorCode.java
@@ -9,6 +9,7 @@ import umc.server.global.apiPayload.code.BaseErrorCode;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
 
+    MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER400_1", "이미 존재하는 아이디입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "존재하지 않는 회원입니다.")
     ;
 

--- a/셔나/server/src/main/java/umc/server/domain/member/repository/MemberRepository.java
+++ b/셔나/server/src/main/java/umc/server/domain/member/repository/MemberRepository.java
@@ -4,7 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import umc.server.domain.member.entity.Member;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/셔나/server/src/main/java/umc/server/domain/member/service/MemberService.java
+++ b/셔나/server/src/main/java/umc/server/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package umc.server.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import umc.server.domain.member.converter.MemberConverter;
 import umc.server.domain.member.dto.MemberReqDTO;
@@ -23,9 +24,19 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final FoodRepository foodRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public MemberResDTO.JoinResultDTO join(MemberReqDTO.JoinDTO request) {
-        Member member = MemberConverter.toMember(request);
+        // 아이디 중복 체크
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new MemberException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        // Member 엔티티 생성
+        Member member = MemberConverter.toMember(request, encodedPassword);
 
         // 약관 동의 연관관계 설정
         TermsAgreed termsAgreed = MemberConverter.toTermsAgreed(request.terms());

--- a/셔나/server/src/main/java/umc/server/global/config/SecurityConfig.java
+++ b/셔나/server/src/main/java/umc/server/global/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import umc.server.global.security.CustomAccessDenied;
+import umc.server.global.security.CustomEntryPoint;
 
 @EnableWebSecurity
 @Configuration
@@ -21,7 +23,7 @@ public class SecurityConfig {
             "/swagger-resources/**",
             "/v3/api-docs/**",
 
-            // 로그인
+            // 회원가입
             "/api/v1/members/signup"
     };
 
@@ -41,6 +43,10 @@ public class SecurityConfig {
                         .logoutUrl("/logout")
                         .logoutSuccessUrl("/login?logout")
                         .permitAll()
+                )
+                .exceptionHandling(exception -> exception
+                        .accessDeniedHandler(customAccessDenied())
+                        .authenticationEntryPoint(customEntryPoint())
                 );
 
         return http.build();
@@ -49,5 +55,15 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CustomAccessDenied customAccessDenied() {
+        return new CustomAccessDenied();
+    }
+
+    @Bean
+    public CustomEntryPoint customEntryPoint() {
+        return new CustomEntryPoint();
     }
 }

--- a/셔나/server/src/main/java/umc/server/global/config/SecurityConfig.java
+++ b/셔나/server/src/main/java/umc/server/global/config/SecurityConfig.java
@@ -1,0 +1,53 @@
+package umc.server.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final String[] allowUris = {
+            // Swagger
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+
+            // 로그인
+            "/api/v1/members/signup"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers(allowUris).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .defaultSuccessUrl("/swagger-ui/index.html", true)
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .permitAll()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/셔나/server/src/main/java/umc/server/global/security/CustomAccessDenied.java
+++ b/셔나/server/src/main/java/umc/server/global/security/CustomAccessDenied.java
@@ -1,0 +1,31 @@
+package umc.server.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import umc.server.global.apiPayload.ApiResponse;
+import umc.server.global.apiPayload.code.BaseErrorCode;
+import umc.server.global.apiPayload.code.GeneralErrorCode;
+
+import java.io.IOException;
+
+public class CustomAccessDenied implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        BaseErrorCode code = GeneralErrorCode.FORBIDDEN;
+
+        // 응답 Content-Type, HTTP 상태코드 정의
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(code.getStatus().value());
+
+        // Response Body에 응답 통일한 객체를 넣기
+        ApiResponse<Void> errorResponse = ApiResponse.onFailure(code,null);
+
+        // 실제 Response로 덮어쓰기
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/셔나/server/src/main/java/umc/server/global/security/CustomEntryPoint.java
+++ b/셔나/server/src/main/java/umc/server/global/security/CustomEntryPoint.java
@@ -1,0 +1,32 @@
+package umc.server.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import umc.server.global.apiPayload.ApiResponse;
+import umc.server.global.apiPayload.code.BaseErrorCode;
+import umc.server.global.apiPayload.code.GeneralErrorCode;
+
+import java.io.IOException;
+
+public class CustomEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        BaseErrorCode code = GeneralErrorCode.UNAUTHORIZED;
+
+        // 응답 Content-Type, HTTP 상태코드 정의
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(code.getStatus().value());
+
+        // Response Body에 응답 통일한 객체를 넣기
+        ApiResponse<Void> errorResponse = ApiResponse.onFailure(code,null);
+
+        // 실제 Response로 덮어쓰기
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/셔나/server/src/main/java/umc/server/global/security/entity/CustomUserDetails.java
+++ b/셔나/server/src/main/java/umc/server/global/security/entity/CustomUserDetails.java
@@ -1,0 +1,32 @@
+package umc.server.global.security.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import umc.server.domain.member.entity.Member;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getUsername();
+    }
+}

--- a/셔나/server/src/main/java/umc/server/global/security/service/CustomUserDetailsService.java
+++ b/셔나/server/src/main/java/umc/server/global/security/service/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package umc.server.global.security.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import umc.server.domain.member.entity.Member;
+import umc.server.domain.member.exception.MemberException;
+import umc.server.domain.member.exception.code.MemberErrorCode;
+import umc.server.domain.member.repository.MemberRepository;
+import umc.server.global.security.entity.CustomUserDetails;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        return new CustomUserDetails(member);
+    }
+}


### PR DESCRIPTION
## Summary
- Spring Security를 적용하여 인증 체계를 구축하고, 요구사항에 맞춰 이메일 기반의 회원가입 API를 구현했습니다.

## Related Issue
- close #61 

## Describe your code
- `SecurityConfig`를 통해 회원가입 경로(`api/v1/members/signup`)는 `permitAll()`로 설정하고, 그 외 API는 인증을 요구하도록 설정했습니다.
- `CustomUserDetailsService`를 구현하여 DB에서 이메일 기반으로 회원을 조회합니다.
- `BCryptPasswordEncoder`를 빈으로 등록하여 회원가입 시 비밀번호를 안전하게 암호화하여 저장합니다.
- 인증/인가 실패 시 통일된 응답을 반환하기 위해 `AuthenticationEntryPoint`와 `AccessDeniedHandler`를 구현했습니다.

## Checklist
- [x] 리뷰어 등록
